### PR TITLE
feat: Add internationalization (i18n) support

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,11 +11,48 @@ import sitemap from '@astrojs/sitemap';
 
 import expressiveCode from 'astro-expressive-code';
 
+import rehypeExternalLinks from 'rehype-external-links';
+
+import { defaultLang, supportedLangs, localeMap } from './src/i18n/translations';
+
 // https://astro.build/config
 export default defineConfig({
-    integrations: [react(), expressiveCode(), mdx(), sitemap()],
+    integrations: [
+        react(),
+        expressiveCode(),
+        mdx(),
+        sitemap({
+            i18n: {
+                defaultLocale: defaultLang,
+                locales: localeMap,
+            },
+        }),
+    ],
     site: process.env.SITE_URL || 'http://localhost:4321',
     base: process.env.BASE_PATH || '/',
+
+    i18n: {
+        locales: [...supportedLangs],
+        defaultLocale: defaultLang,
+        routing: {
+            prefixDefaultLocale: false,
+        },
+    },
+
+    markdown: {
+        rehypePlugins: [
+            [
+                rehypeExternalLinks,
+                {
+                    content: { type: 'text', value: ' 🔗' }
+                }
+            ]
+         ],
+    },
+
+    prefetch: {
+        prefetchAll: true
+    },
 
     vite: {
         plugins: [tailwindcss()],

--- a/cspell.json
+++ b/cspell.json
@@ -1,19 +1,24 @@
 {
   "version": "0.2",
   "language": "en",
+  "import": ["@cspell/dict-de-de/cspell-ext.json"],
   "words": [
     "Amand",
+    "Amazonbot",
+    "Bytespider",
     "Jérémy",
     "astro",
     "astrojs",
     "bioinformatics",
     "daisyui",
     "frontmatter",
+    "hreflang",
     "lucide",
     "tailwindcss"
   ],
   "ignorePaths": ["node_modules", "dist", ".astro", "pnpm-lock.yaml"],
   "enableFiletypes": ["mdx", "md"],
+  "files": ["src/blog/**/*.{md,mdx}"],
   "overrides": [
     {
       "filename": "src/blog/**/*.{md,mdx}",
@@ -23,6 +28,10 @@
           "ignoreRegExpList": ["/^---[\\s\\S]*?^---/m"]
         }
       ]
+    },
+    {
+      "filename": "src/blog/de/**/*.{md,mdx}",
+      "language": "de,en"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "astro-expressive-code": "^0.41.6",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "rehype-external-links": "^3.0.0",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
+    "@cspell/dict-de-de": "^4.1.2",
     "@tailwindcss/typography": "^0.5.19",
     "@typescript-eslint/parser": "^8.54.0",
     "cspell": "^9.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-dom:
         specifier: ^19.2.3
         version: 19.2.4(react@19.2.4)
+      rehype-external-links:
+        specifier: ^3.0.0
+        version: 3.0.0
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -51,6 +54,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.6
         version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+      '@cspell/dict-de-de':
+        specifier: ^4.1.2
+        version: 4.1.2
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.1.18)
@@ -310,6 +316,9 @@ packages:
 
   '@cspell/dict-data-science@2.0.13':
     resolution: {integrity: sha512-l1HMEhBJkPmw4I2YGVu2eBSKM89K9pVF+N6qIr5Uo5H3O979jVodtuwP8I7LyPrJnC6nz28oxeGRCLh9xC5CVA==}
+
+  '@cspell/dict-de-de@4.1.2':
+    resolution: {integrity: sha512-pRb5bIQc2pJU6bVEsSfhMkB+XXJauaXg3KS+KjO38HBHAe2vg611keKYSkry90Rbn2KVMOLAVjN0hN/qiy5X0A==}
 
   '@cspell/dict-django@4.1.6':
     resolution: {integrity: sha512-SdbSFDGy9ulETqNz15oWv2+kpWLlk8DJYd573xhIkeRdcXOjskRuxjSZPKfW7O3NxN/KEf3gm3IevVOiNuFS+w==}
@@ -2447,6 +2456,10 @@ packages:
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
+  is-absolute-url@4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -3402,6 +3415,9 @@ packages:
 
   rehype-expressive-code@0.41.6:
     resolution: {integrity: sha512-aBMX8kxPtjmDSFUdZlAWJkMvsQ4ZMASfee90JWIAV8tweltXLzkWC3q++43ToTelI8ac5iC0B3/S/Cl4Ql1y2g==}
+
+  rehype-external-links@3.0.0:
+    resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
 
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
@@ -4565,6 +4581,8 @@ snapshots:
   '@cspell/dict-dart@2.3.2': {}
 
   '@cspell/dict-data-science@2.0.13': {}
+
+  '@cspell/dict-de-de@4.1.2': {}
 
   '@cspell/dict-django@4.1.6': {}
 
@@ -6931,6 +6949,8 @@ snapshots:
 
   iron-webcrypto@1.2.1: {}
 
+  is-absolute-url@4.0.1: {}
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -8129,6 +8149,15 @@ snapshots:
   rehype-expressive-code@0.41.6:
     dependencies:
       expressive-code: 0.41.6
+
+  rehype-external-links@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-is-element: 3.0.0
+      is-absolute-url: 4.0.1
+      space-separated-tokens: 2.0.2
+      unist-util-visit: 5.1.0
 
   rehype-parse@9.0.1:
     dependencies:

--- a/src/blog/20260127-helloworld.mdx
+++ b/src/blog/20260127-helloworld.mdx
@@ -7,6 +7,8 @@ image:
   url: 'https://docs.astro.build/assets/rose.webp'
   alt: 'The Astro logo on a dark background with a pink glow.'
 tags: ['blogging']
+lang: 'en'
+translationSlug: 'de/20260127-helloworld'
 ---
 
 Welcome to my _new blog_ about different topics around cloud computing,

--- a/src/blog/de/20260127-helloworld.mdx
+++ b/src/blog/de/20260127-helloworld.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Hallo Welt'
+pubDate: 2026-01-27
+description: 'Dies ist der erste Beitrag meines neuen Astro-Blogs.'
+author: 'Jérémy Amand'
+image:
+  url: 'https://docs.astro.build/assets/rose.webp'
+  alt: 'Das Astro-Logo auf dunklem Hintergrund mit rosa Leuchten.'
+tags: ['blogging']
+lang: 'de'
+translationSlug: '20260127-helloworld'
+---
+
+Willkommen auf meinem _neuen Blog_ über verschiedene Themen rund um Cloud Computing,
+meinen Bioinformatik-Hintergrund und europäische souveräne Lösungen!

--- a/src/components/BlogPostLink.astro
+++ b/src/components/BlogPostLink.astro
@@ -1,6 +1,45 @@
 ---
 // BlogPostLink component - displays a single blog post link in a list
-const { title, url } = Astro.props;
+import type { AvailableLanguage } from '../i18n/blog-utils';
+import { getLangName, getDateLocale } from '../i18n/utils';
+import type { Lang } from '../i18n/translations';
+
+interface Props {
+	title: string;
+	url: string;
+	pubDate: Date;
+	lang: Lang; // Used for date formatting
+	availableLanguages: AvailableLanguage[];
+}
+
+const { title, url, pubDate, lang, availableLanguages } = Astro.props;
+
+const formattedDate = pubDate.toLocaleDateString(getDateLocale(lang), {
+	day: 'numeric',
+	month: 'short',
+	year: 'numeric',
+});
 ---
 
-<li><a href={url}>{title}</a></li>
+<li class="flex items-center gap-2">
+	<time
+		datetime={pubDate.toISOString().split('T')[0]}
+		class="text-sm opacity-60"
+	>
+		{formattedDate}
+	</time>
+	<a href={url}>{title}</a>
+	<span class="flex gap-1">
+		{
+			availableLanguages.map(({ lang: langCode, url: langUrl }) => (
+				<a
+					href={langUrl}
+					aria-label={getLangName(langCode)}
+					class="badge badge-outline badge-sm no-underline"
+				>
+					{langCode.toUpperCase()}
+				</a>
+			))
+		}
+	</span>
+</li>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,20 +1,43 @@
 ---
 // Header component - site header with navigation
 import ThemeToggle from './ThemeToggle.astro';
+import LanguageSwitcher from './LanguageSwitcher.astro';
+import { defaultLang, type Lang } from '../i18n/translations';
+import { useTranslations, getLocalizedPath } from '../i18n/utils';
+
+interface Props {
+	lang?: Lang;
+}
+
+const { lang = defaultLang } = Astro.props;
+const t = useTranslations(lang);
+
+const navLinks = [
+	{ href: getLocalizedPath('/', lang), label: t('nav.home') },
+	{ href: getLocalizedPath('/about/', lang), label: t('nav.about') },
+	{ href: getLocalizedPath('/blog/', lang), label: t('nav.blog') },
+];
 ---
 
 <header class="navbar bg-base-200 px-4">
 	<div class="flex-1">
-		<a href="/" class="text-xl font-bold">Jérémy Amand</a>
+		<a href={getLocalizedPath('/', lang)} class="text-xl font-bold"
+			>Jérémy Amand</a
+		>
 	</div>
 	<nav class="flex-none">
 		<ul class="menu menu-horizontal gap-1 px-1">
-			<li><a href="/">Home</a></li>
-			<li><a href="/about/">About</a></li>
-			<li><a href="/blog/">Blog</a></li>
+			{
+				navLinks.map((link) => (
+					<li>
+						<a href={link.href}>{link.label}</a>
+					</li>
+				))
+			}
 		</ul>
 	</nav>
-	<div class="ml-1">
+	<div class="ml-1 flex items-center gap-1">
+		<LanguageSwitcher lang={lang} />
 		<ThemeToggle />
 	</div>
 </header>

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -1,0 +1,49 @@
+---
+import { Languages } from '@lucide/astro';
+import { supportedLangs, type Lang } from '../i18n/translations';
+import { useTranslations, getAlternateLocaleUrl } from '../i18n/utils';
+
+interface Props {
+	lang: Lang;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang);
+const currentUrl = Astro.url;
+
+const languages = supportedLangs.map((l) => ({
+	code: l,
+	label: t(`lang.${l}`),
+	href: getAlternateLocaleUrl(currentUrl, l),
+	isCurrent: l === lang,
+}));
+---
+
+<details class="dropdown dropdown-end">
+	<summary class="btn btn-ghost btn-sm gap-1" aria-label={t('lang.switch')}>
+		<Languages class="h-5 w-5" />
+		<span class="hidden sm:inline">{lang.toUpperCase()}</span>
+	</summary>
+	<ul
+		class="menu dropdown-content bg-base-200 rounded-box z-50 mt-2 w-36 p-2 shadow-lg"
+	>
+		{
+			languages.map((language) => (
+				<li>
+					<a
+						href={language.href}
+						class:list={[
+							'flex justify-between',
+							{ active: language.isCurrent },
+						]}
+						aria-current={language.isCurrent ? 'page' : undefined}
+						aria-label={language.label}
+					>
+						<span lang={language.code}>{language.label}</span>
+						{language.isCurrent && <span class="status" aria-hidden="true" />}
+					</a>
+				</li>
+			))
+		}
+	</ul>
+</details>

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -1,0 +1,7 @@
+---
+// Prose component - wraps content with Tailwind Typography styling
+---
+
+<div class="prose max-w-none">
+	<slot />
+</div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,8 @@
 import { glob } from 'astro/loaders';
 import { defineCollection } from 'astro:content';
 import { z } from 'astro/zod';
+import { supportedLangs, defaultLang } from './i18n/translations';
+
 // Define a `loader` and `schema` for each collection
 const blog = defineCollection({
 	loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/blog' }),
@@ -14,6 +16,9 @@ const blog = defineCollection({
 			alt: z.string(),
 		}),
 		tags: z.array(z.string()),
+		lang: z.enum(supportedLangs).default(defaultLang),
+		// Link to translation (use the slug of the other language version)
+		translationSlug: z.string().optional(),
 	}),
 });
 // Export a single `collections` object to register your collection(s)

--- a/src/i18n/blog-utils.ts
+++ b/src/i18n/blog-utils.ts
@@ -1,0 +1,114 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+import { defaultLang, type Lang } from './translations';
+
+export type BlogPost = CollectionEntry<'blog'>;
+
+/**
+ * Get all posts for a specific language
+ */
+export async function getPostsByLang(lang: Lang): Promise<BlogPost[]> {
+	const allPosts = await getCollection('blog');
+	return allPosts.filter((post) => post.data.lang === lang);
+}
+
+/**
+ * Get a post and its translation (if available)
+ */
+export async function getPostWithTranslation(post: BlogPost): Promise<{
+	post: BlogPost;
+	translation?: BlogPost;
+}> {
+	if (!post.data.translationSlug) {
+		return { post };
+	}
+
+	const allPosts = await getCollection('blog');
+	const translation = allPosts.find((p) => p.id === post.data.translationSlug);
+
+	return { post, translation };
+}
+
+/**
+ * Check if a post has a translation available
+ */
+export function hasTranslation(post: BlogPost): boolean {
+	return !!post.data.translationSlug;
+}
+
+export type AvailableLanguage = {
+	lang: Lang;
+	url: string;
+};
+
+/**
+ * Get all posts with available language versions
+ */
+export async function getPostsWithLanguages(lang: Lang): Promise<
+	Array<{
+		post: BlogPost;
+		availableLanguages: AvailableLanguage[];
+	}>
+> {
+	const posts = await getPostsByLang(lang);
+	const allPosts = await getCollection('blog');
+
+	return posts.map((post) => {
+		const availableLanguages: AvailableLanguage[] = [
+			{ lang: post.data.lang as Lang, url: getPostUrl(post) },
+		];
+
+		const translationSlug = post.data.translationSlug;
+		const translation = translationSlug
+			? allPosts.find((p) => p.id === translationSlug)
+			: undefined;
+
+		if (translation) {
+			availableLanguages.push({
+				lang: translation.data.lang as Lang,
+				url: getPostUrl(translation),
+			});
+		}
+
+		return { post, availableLanguages };
+	});
+}
+
+/**
+ * Get available languages for a single post
+ */
+export async function getAvailableLanguages(
+	post: BlogPost,
+): Promise<AvailableLanguage[]> {
+	const languages: AvailableLanguage[] = [
+		{ lang: post.data.lang as Lang, url: getPostUrl(post) },
+	];
+
+	if (post.data.translationSlug) {
+		const allPosts = await getCollection('blog');
+		const translation = allPosts.find(
+			(p) => p.id === post.data.translationSlug,
+		);
+		if (translation) {
+			languages.push({
+				lang: translation.data.lang as Lang,
+				url: getPostUrl(translation),
+			});
+		}
+	}
+
+	return languages;
+}
+
+/**
+ * Get the URL for a blog post based on language
+ */
+export function getPostUrl(post: BlogPost): string {
+	const lang = post.data.lang;
+	// Remove language folder prefix (e.g., "de/") from the slug for URL
+	const slug = post.id.replace(/^[a-z]{2}\//, '');
+
+	if (lang === defaultLang) {
+		return `/posts/${slug}/`;
+	}
+	return `/${lang}/posts/${slug}/`;
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1,0 +1,95 @@
+export const defaultLang = 'en' as const;
+export const supportedLangs = ['en', 'de'] as const;
+export type Lang = (typeof supportedLangs)[number];
+
+// Language metadata (flag emoji and native name)
+export const langMeta: Record<Lang, { flag: string; name: string }> = {
+	en: { flag: '🇬🇧', name: 'English' },
+	de: { flag: '🇩🇪', name: 'Deutsch' },
+};
+
+// Full locale codes for date formatting and sitemap
+export const localeMap: Record<Lang, string> = {
+	en: 'en-GB',
+	de: 'de-DE',
+};
+
+export const translations = {
+	en: {
+		// Navigation
+		'nav.home': 'Home',
+		'nav.about': 'About',
+		'nav.blog': 'Blog',
+
+		// Common UI
+		'common.readMore': 'Read more',
+		'common.backToHome': 'Go back home',
+		'common.browseByTags': 'Browse by tags',
+		'common.skipToContent': 'Skip to main content',
+
+		// Meta descriptions
+		'meta.home':
+			'Personal website of Jérémy Amand - software developer sharing thoughts and projects.',
+		'meta.about':
+			'Learn more about Jérémy Amand, his background, and interests.',
+		'meta.blog':
+			'Articles and thoughts on software development and technology.',
+		'meta.tags': 'Browse blog posts by topic and category.',
+
+		// Blog
+		'blog.title': 'Blog',
+		'blog.publishedOn': 'Published',
+		'blog.author': 'Author',
+		'blog.availableIn': 'Translation',
+		'blog.postsTaggedWith': 'Posts tagged with',
+		'blog.tags': 'Tags',
+
+		// 404
+		'404.title': '404 - Page Not Found',
+		'404.message': "The page you're looking for doesn't exist.",
+
+		// Language switcher
+		'lang.switch': 'Switch language',
+		'lang.en': '🇬🇧 English',
+		'lang.de': '🇩🇪 Deutsch',
+	},
+	de: {
+		// Navigation
+		'nav.home': 'Startseite',
+		'nav.about': 'Über mich',
+		'nav.blog': 'Blog',
+
+		// Common UI
+		'common.readMore': 'Weiterlesen',
+		'common.backToHome': 'Zurück zur Startseite',
+		'common.browseByTags': 'Nach Tags durchsuchen',
+		'common.skipToContent': 'Zum Hauptinhalt springen',
+
+		// Meta descriptions
+		'meta.home':
+			'Persönliche Webseite von Jérémy Amand - Softwareentwickler mit Gedanken und Projekten.',
+		'meta.about':
+			'Erfahren Sie mehr über Jérémy Amand, seinen Hintergrund und seine Interessen.',
+		'meta.blog': 'Artikel und Gedanken zu Softwareentwicklung und Technologie.',
+		'meta.tags': 'Blogbeiträge nach Thema und Kategorie durchsuchen.',
+
+		// Blog
+		'blog.title': 'Blog',
+		'blog.publishedOn': 'Veröffentlicht',
+		'blog.author': 'Autor',
+		'blog.availableIn': 'Übersetzung',
+		'blog.postsTaggedWith': 'Beiträge mit Tag',
+		'blog.tags': 'Tags',
+
+		// 404
+		'404.title': '404 - Seite nicht gefunden',
+		'404.message': 'Die gesuchte Seite existiert nicht.',
+
+		// Language switcher
+		'lang.switch': 'Sprache wechseln',
+		'lang.en': '🇬🇧 English',
+		'lang.de': '🇩🇪 Deutsch',
+	},
+} as const;
+
+export type TranslationKey = keyof (typeof translations)['en'];

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,0 +1,87 @@
+import {
+	translations,
+	defaultLang,
+	supportedLangs,
+	langMeta,
+	localeMap,
+	type Lang,
+	type TranslationKey,
+} from './translations';
+
+/**
+ * Get the current language from the URL
+ */
+export function getLangFromUrl(url: URL): Lang {
+	const [, lang] = url.pathname.split('/');
+	if (supportedLangs.includes(lang as Lang)) {
+		return lang as Lang;
+	}
+	return defaultLang;
+}
+
+/**
+ * Get a translation for a specific key
+ */
+export function t(lang: Lang, key: TranslationKey): string {
+	return translations[lang][key] ?? translations[defaultLang][key] ?? key;
+}
+
+/**
+ * Create a translation function bound to a specific language
+ */
+export function useTranslations(lang: Lang) {
+	return (key: TranslationKey) => t(lang, key);
+}
+
+/**
+ * Get the localized path for a given path
+ */
+export function getLocalizedPath(path: string, lang: Lang): string {
+	// Remove leading slash for processing
+	const cleanPath = path.startsWith('/') ? path.slice(1) : path;
+
+	// Remove any existing locale prefix
+	const pathWithoutLocale = supportedLangs.some((l) =>
+		cleanPath.startsWith(`${l}/`),
+	)
+		? cleanPath.split('/').slice(1).join('/')
+		: cleanPath;
+
+	// Add locale prefix for non-default language
+	if (lang === defaultLang) {
+		return `/${pathWithoutLocale}`;
+	}
+	return `/${lang}/${pathWithoutLocale}`;
+}
+
+/**
+ * Get the alternate language URL for language switcher
+ */
+export function getAlternateLocaleUrl(
+	currentUrl: URL,
+	targetLang: Lang,
+): string {
+	const currentPath = currentUrl.pathname;
+	return getLocalizedPath(currentPath, targetLang);
+}
+
+/**
+ * Get the date locale string for Intl.DateTimeFormat based on language
+ */
+export function getDateLocale(lang: Lang): string {
+	return localeMap[lang] || localeMap[defaultLang];
+}
+
+/**
+ * Get the flag emoji for a language
+ */
+export function getLangFlag(lang: Lang): string {
+	return langMeta[lang]?.flag || langMeta[defaultLang].flag;
+}
+
+/**
+ * Get the native name for a language (e.g., "Deutsch" for German)
+ */
+export function getLangName(lang: Lang): string {
+	return langMeta[lang]?.name || langMeta[defaultLang].name;
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,17 +3,23 @@
 import '../styles/global.css';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import Prose from '../components/Prose.astro';
+import { defaultLang, supportedLangs, type Lang } from '../i18n/translations';
+import { useTranslations, getAlternateLocaleUrl } from '../i18n/utils';
 
 interface Props {
 	title?: string;
 	description?: string;
+	lang?: Lang;
 }
 
-const { title = 'Jérémy Amand', description } = Astro.props;
+const { title = 'Jérémy Amand', description, lang = defaultLang } = Astro.props;
+const t = useTranslations(lang);
+const currentUrl = Astro.url;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={lang}>
 	<head>
 		<meta charset="UTF-8" />
 		<script is:inline>
@@ -29,6 +35,30 @@ const { title = 'Jérémy Amand', description } = Astro.props;
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="sitemap" href="/sitemap-index.xml" />
+		{
+			supportedLangs.map((l) => (
+				<link
+					rel="alternate"
+					hreflang={l}
+					href={new URL(getAlternateLocaleUrl(currentUrl, l), Astro.site).href}
+				/>
+			))
+		}
+		<link
+			rel="alternate"
+			hreflang="x-default"
+			href={new URL(getAlternateLocaleUrl(currentUrl, defaultLang), Astro.site)
+				.href}
+		/>
+		<link
+			rel="alternate"
+			type="application/rss+xml"
+			title="Jérémy Amand | Blog"
+			href={new URL(
+				lang === defaultLang ? '/rss.xml' : `/${lang}/rss.xml`,
+				Astro.site,
+			).href}
+		/>
 		<meta name="generator" content={Astro.generator} />
 		{description && <meta name="description" content={description} />}
 		<title>{title}</title>
@@ -38,14 +68,16 @@ const { title = 'Jérémy Amand', description } = Astro.props;
 			href="#main-content"
 			class="bg-base-100 text-base-content sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded focus:px-4 focus:py-2"
 		>
-			Skip to main content
+			{t('common.skipToContent')}
 		</a>
-		<Header />
+		<Header lang={lang} />
 		<main
 			id="main-content"
-			class="prose container mx-auto max-w-4xl flex-1 px-4 py-8"
+			class="container mx-auto max-w-4xl flex-1 px-4 py-8"
 		>
-			<slot />
+			<Prose>
+				<slot />
+			</Prose>
 		</main>
 		<Footer />
 	</body>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -1,11 +1,30 @@
 ---
 // Layout for individual blog posts rendered from markdown/mdx
 import Layout from './Layout.astro';
+import { defaultLang, type Lang } from '../i18n/translations';
+import {
+	useTranslations,
+	getDateLocale,
+	getLangFlag,
+	getLangName,
+} from '../i18n/utils';
+import { getPostUrl, type BlogPost } from '../i18n/blog-utils';
 
-const { frontmatter } = Astro.props;
+interface Props {
+	frontmatter: BlogPost['data'];
+	translation?: BlogPost;
+}
+
+const { frontmatter, translation } = Astro.props;
+const lang = (frontmatter.lang || defaultLang) as Lang;
+const t = useTranslations(lang);
 ---
 
-<Layout title={frontmatter.title} description={frontmatter.description}>
+<Layout
+	title={frontmatter.title}
+	description={frontmatter.description}
+	lang={lang}
+>
 	<article>
 		<header
 			class="not-prose mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
@@ -13,11 +32,11 @@ const { frontmatter } = Astro.props;
 			<h1 class="m-0 text-3xl font-bold sm:text-4xl">{frontmatter.title}</h1>
 			<dl class="stats stats-horizontal shadow">
 				<div class="stat px-4 py-2">
-					<dt class="stat-title">Published</dt>
+					<dt class="stat-title">{t('blog.publishedOn')}</dt>
 					<dd class="stat-value text-base">
 						<time datetime={frontmatter.pubDate.toISOString().split('T')[0]}>
 							{
-								frontmatter.pubDate.toLocaleDateString('en-GB', {
+								frontmatter.pubDate.toLocaleDateString(getDateLocale(lang), {
 									day: 'numeric',
 									month: 'short',
 									year: 'numeric',
@@ -27,9 +46,26 @@ const { frontmatter } = Astro.props;
 					</dd>
 				</div>
 				<div class="stat px-4 py-2">
-					<dt class="stat-title">Author</dt>
+					<dt class="stat-title">{t('blog.author')}</dt>
 					<dd class="stat-value text-base">{frontmatter.author}</dd>
 				</div>
+				{
+					translation && (
+						<div class="stat px-4 py-2">
+							<dt class="stat-title">{t('blog.availableIn')}</dt>
+							<dd class="stat-value text-base">
+								<a
+									href={getPostUrl(translation)}
+									class="text-2xl no-underline opacity-90 transition-opacity hover:opacity-100"
+									title={getLangName(translation.data.lang as Lang)}
+									aria-label={getLangName(translation.data.lang as Lang)}
+								>
+									{getLangFlag(translation.data.lang as Lang)}
+								</a>
+							</dd>
+						</div>
+					)
+				}
 			</dl>
 		</header>
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,12 +1,14 @@
 ---
 // 404 Not Found page
 import Layout from '../layouts/Layout.astro';
+import { useTranslations } from '../i18n/utils';
+
+const lang = 'en';
+const t = useTranslations(lang);
 ---
 
-<Layout>
-	<main>
-		<h1>404 - Page Not Found</h1>
-		<p>The page you're looking for doesn't exist.</p>
-		<a href="/">Go back home</a>
-	</main>
+<Layout lang={lang} title={t('404.title')} description={t('404.message')}>
+	<h1>{t('404.title')}</h1>
+	<p>{t('404.message')}</p>
+	<a href="/">{t('common.backToHome')}</a>
 </Layout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,8 +1,13 @@
 ---
+// About page
 import Layout from '../layouts/Layout.astro';
+import { useTranslations } from '../i18n/utils';
+
+const lang = 'en';
+const t = useTranslations(lang);
 ---
 
-<Layout>
+<Layout lang={lang} description={t('meta.about')}>
 	<h1>About Me</h1>
 	<p>
 		Welcome to my personal website. This is where I share my thoughts and

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,20 +1,29 @@
 ---
-// Blog listing page - displays all posts from the blog collection
-import { getCollection } from 'astro:content';
+// Blog listing page - displays all posts from the blog collection (English)
 import Layout from '../layouts/Layout.astro';
 import BlogPostLink from '../components/BlogPostLink.astro';
+import { getPostsWithLanguages, getPostUrl } from '../i18n/blog-utils';
+import { useTranslations } from '../i18n/utils';
 
-const allPosts = await getCollection('blog');
+const lang = 'en';
+const t = useTranslations(lang);
+const postsWithLanguages = await getPostsWithLanguages(lang);
 ---
 
-<Layout>
-	<h1>Blog</h1>
+<Layout lang={lang} description={t('meta.blog')}>
+	<h1>{t('blog.title')}</h1>
 	<ul>
 		{
-			allPosts.map((post) => (
-				<BlogPostLink url={`/posts/${post.id}/`} title={post.data.title} />
+			postsWithLanguages.map(({ post, availableLanguages }) => (
+				<BlogPostLink
+					url={getPostUrl(post)}
+					title={post.data.title}
+					pubDate={post.data.pubDate}
+					lang={lang}
+					availableLanguages={availableLanguages}
+				/>
 			))
 		}
 	</ul>
-	<a href="/tags/">Browse by tags</a>
+	<a href="/tags/">{t('common.browseByTags')}</a>
 </Layout>

--- a/src/pages/de/about.astro
+++ b/src/pages/de/about.astro
@@ -1,0 +1,16 @@
+---
+// About page (German)
+import Layout from '../../layouts/Layout.astro';
+import { useTranslations } from '../../i18n/utils';
+
+const lang = 'de';
+const t = useTranslations(lang);
+---
+
+<Layout lang={lang} description={t('meta.about')}>
+	<h1>Über mich</h1>
+	<p>
+		Willkommen auf meiner persönlichen Webseite. Hier teile ich meine Gedanken
+		und Projekte.
+	</p>
+</Layout>

--- a/src/pages/de/blog.astro
+++ b/src/pages/de/blog.astro
@@ -1,0 +1,33 @@
+---
+// Blog listing page - displays all posts from the blog collection (German)
+import Layout from '../../layouts/Layout.astro';
+import BlogPostLink from '../../components/BlogPostLink.astro';
+import { getPostsWithLanguages, getPostUrl } from '../../i18n/blog-utils';
+import { useTranslations, getLocalizedPath } from '../../i18n/utils';
+
+const lang = 'de';
+const t = useTranslations(lang);
+const postsWithLanguages = await getPostsWithLanguages(lang);
+---
+
+<Layout lang={lang} description={t('meta.blog')}>
+	<h1>{t('blog.title')}</h1>
+	{
+		postsWithLanguages.length > 0 ? (
+			<ul>
+				{postsWithLanguages.map(({ post, availableLanguages }) => (
+					<BlogPostLink
+						url={getPostUrl(post)}
+						title={post.data.title}
+						pubDate={post.data.pubDate}
+						lang={lang}
+						availableLanguages={availableLanguages}
+					/>
+				))}
+			</ul>
+		) : (
+			<p>Noch keine deutschen Beiträge verfügbar.</p>
+		)
+	}
+	<a href={getLocalizedPath('/tags/', lang)}>{t('common.browseByTags')}</a>
+</Layout>

--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -1,0 +1,14 @@
+---
+// Homepage (German)
+import Layout from '../../layouts/Layout.astro';
+import { getLocalizedPath, useTranslations } from '../../i18n/utils';
+
+const lang = 'de';
+const t = useTranslations(lang);
+---
+
+<Layout lang={lang} description={t('meta.home')}>
+	<h1>Willkommen</h1>
+	<p>Dies ist meine persönliche Webseite.</p>
+	<a href={getLocalizedPath('/blog/', lang)} class="link">Meinen Blog lesen</a>
+</Layout>

--- a/src/pages/de/posts/[...slug].astro
+++ b/src/pages/de/posts/[...slug].astro
@@ -1,0 +1,26 @@
+---
+// Dynamic blog post page - renders individual posts from the blog collection (German)
+import { getCollection, render } from 'astro:content';
+import MarkdownPostLayout from '../../../layouts/MarkdownPostLayout.astro';
+import { getPostWithTranslation } from '../../../i18n/blog-utils';
+
+export async function getStaticPaths() {
+	const posts = await getCollection('blog');
+	// Only generate paths for German posts
+	const germanPosts = posts.filter((post) => post.data.lang === 'de');
+
+	return germanPosts.map((post) => ({
+		// Remove de/ folder prefix from URL slug
+		params: { slug: post.id.replace(/^de\//, '') },
+		props: { post },
+	}));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+const { translation } = await getPostWithTranslation(post);
+---
+
+<MarkdownPostLayout frontmatter={post.data} translation={translation}>
+	<Content />
+</MarkdownPostLayout>

--- a/src/pages/de/rss.xml.ts
+++ b/src/pages/de/rss.xml.ts
@@ -1,0 +1,26 @@
+// RSS feed generator - provides an RSS feed of German blog posts
+import rss from '@astrojs/rss';
+import { getPostsByLang, getPostUrl } from '../../i18n/blog-utils';
+import { getImageMimeType } from '../../utils';
+import type { APIContext } from 'astro';
+
+export async function GET({ site }: APIContext) {
+	const posts = await getPostsByLang('de');
+	return rss({
+		title: 'Jérémy Amand | Blog',
+		description: 'Mein persönlicher Blog',
+		site: site!,
+		items: posts.map((post) => ({
+			title: post.data.title,
+			pubDate: post.data.pubDate,
+			description: post.data.description,
+			link: getPostUrl(post),
+			enclosure: {
+				url: new URL(post.data.image.url, site).href,
+				length: 0,
+				type: getImageMimeType(post.data.image.url),
+			},
+		})),
+		customData: `<language>de</language>`,
+	});
+}

--- a/src/pages/de/tags/[tag].astro
+++ b/src/pages/de/tags/[tag].astro
@@ -1,0 +1,66 @@
+---
+// Dynamic tag page - shows all German posts with a specific tag
+import Layout from '../../../layouts/Layout.astro';
+import BlogPostLink from '../../../components/BlogPostLink.astro';
+import {
+	getPostUrl,
+	type AvailableLanguage,
+	type BlogPost,
+} from '../../../i18n/blog-utils';
+import { useTranslations } from '../../../i18n/utils';
+
+const lang = 'de';
+const t = useTranslations(lang);
+
+interface PostWithLanguages {
+	post: BlogPost;
+	availableLanguages: AvailableLanguage[];
+}
+
+export async function getStaticPaths() {
+	const { getPostsByLang, getAvailableLanguages } =
+		await import('../../../i18n/blog-utils');
+	const germanPosts = await getPostsByLang('de');
+	const uniqueTags = [
+		...new Set(germanPosts.map((post) => post.data.tags).flat()),
+	];
+
+	return Promise.all(
+		uniqueTags.map(async (tag) => {
+			const filteredPosts = germanPosts.filter((post) =>
+				post.data.tags.includes(tag),
+			);
+			const postsWithLanguages = await Promise.all(
+				filteredPosts.map(async (post) => ({
+					post,
+					availableLanguages: await getAvailableLanguages(post),
+				})),
+			);
+			return {
+				params: { tag },
+				props: { posts: postsWithLanguages },
+			};
+		}),
+	);
+}
+
+const { tag } = Astro.params;
+const { posts } = Astro.props as { posts: PostWithLanguages[] };
+---
+
+<Layout lang={lang}>
+	<h1>{t('blog.postsTaggedWith')} "{tag}"</h1>
+	<ul>
+		{
+			posts.map(({ post, availableLanguages }) => (
+				<BlogPostLink
+					url={getPostUrl(post)}
+					title={post.data.title}
+					pubDate={post.data.pubDate}
+					lang={lang}
+					availableLanguages={availableLanguages}
+				/>
+			))
+		}
+	</ul>
+</Layout>

--- a/src/pages/de/tags/index.astro
+++ b/src/pages/de/tags/index.astro
@@ -1,0 +1,28 @@
+---
+// Tag index page - lists all unique tags from German blog posts
+import Layout from '../../../layouts/Layout.astro';
+import { getPostsByLang } from '../../../i18n/blog-utils';
+import { useTranslations, getLocalizedPath } from '../../../i18n/utils';
+
+const lang = 'de';
+const t = useTranslations(lang);
+const germanPosts = await getPostsByLang(lang);
+const tags = [...new Set(germanPosts.map((post) => post.data.tags).flat())];
+---
+
+<Layout lang={lang} description={t('meta.tags')}>
+	<h1>{t('blog.tags')}</h1>
+	{
+		tags.length > 0 ? (
+			<ul>
+				{tags.map((tag) => (
+					<li>
+						<a href={getLocalizedPath(`/tags/${tag}/`, lang)}>{tag}</a>
+					</li>
+				))}
+			</ul>
+		) : (
+			<p>Noch keine Tags verfügbar.</p>
+		)
+	}
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,13 @@
 ---
 // Homepage
 import Layout from '../layouts/Layout.astro';
+import { useTranslations } from '../i18n/utils';
+
+const lang = 'en';
+const t = useTranslations(lang);
 ---
 
-<Layout>
+<Layout lang={lang} description={t('meta.home')}>
 	<h1>Welcome</h1>
 	<p>This is my personal website.</p>
 	<a href="/blog/" class="link">Read my blog</a>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,11 +1,15 @@
 ---
-// Dynamic blog post page - renders individual posts from the blog collection
+// Dynamic blog post page - renders individual posts from the blog collection (English)
 import { getCollection, render } from 'astro:content';
 import MarkdownPostLayout from '../../layouts/MarkdownPostLayout.astro';
+import { getPostWithTranslation } from '../../i18n/blog-utils';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
-	return posts.map((post) => ({
+	// Only generate paths for English posts
+	const englishPosts = posts.filter((post) => post.data.lang === 'en');
+
+	return englishPosts.map((post) => ({
 		params: { slug: post.id },
 		props: { post },
 	}));
@@ -13,8 +17,9 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
+const { translation } = await getPostWithTranslation(post);
 ---
 
-<MarkdownPostLayout frontmatter={post.data}>
+<MarkdownPostLayout frontmatter={post.data} translation={translation}>
 	<Content />
 </MarkdownPostLayout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,10 +1,11 @@
-// RSS feed generator - provides an RSS feed of all blog posts
+// RSS feed generator - provides an RSS feed of English blog posts
 import rss from '@astrojs/rss';
-import { getCollection } from 'astro:content';
+import { getPostsByLang, getPostUrl } from '../i18n/blog-utils';
+import { getImageMimeType } from '../utils';
 import type { APIContext } from 'astro';
 
 export async function GET({ site }: APIContext) {
-	const posts = await getCollection('blog');
+	const posts = await getPostsByLang('en');
 	return rss({
 		title: 'Jérémy Amand | Blog',
 		description: 'My personal blog',
@@ -13,7 +14,12 @@ export async function GET({ site }: APIContext) {
 			title: post.data.title,
 			pubDate: post.data.pubDate,
 			description: post.data.description,
-			link: `/posts/${post.id}/`,
+			link: getPostUrl(post),
+			enclosure: {
+				url: new URL(post.data.image.url, site).href,
+				length: 0,
+				type: getImageMimeType(post.data.image.url),
+			},
 		})),
 		customData: `<language>en-us</language>`,
 	});

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,36 +1,65 @@
 ---
-// Dynamic tag page - shows all posts with a specific tag
-import { getCollection } from 'astro:content';
+// Dynamic tag page - shows all English posts with a specific tag
 import Layout from '../../layouts/Layout.astro';
 import BlogPostLink from '../../components/BlogPostLink.astro';
+import {
+	getPostUrl,
+	type AvailableLanguage,
+	type BlogPost,
+} from '../../i18n/blog-utils';
+import { useTranslations } from '../../i18n/utils';
+
+const lang = 'en';
+const t = useTranslations(lang);
+
+interface PostWithLanguages {
+	post: BlogPost;
+	availableLanguages: AvailableLanguage[];
+}
 
 export async function getStaticPaths() {
-	const allPosts = await getCollection('blog');
+	const { getPostsByLang, getAvailableLanguages } =
+		await import('../../i18n/blog-utils');
+	const englishPosts = await getPostsByLang('en');
 	const uniqueTags = [
-		...new Set(allPosts.map((post) => post.data.tags).flat()),
+		...new Set(englishPosts.map((post) => post.data.tags).flat()),
 	];
 
-	return uniqueTags.map((tag) => {
-		const filteredPosts = allPosts.filter((post) =>
-			post.data.tags.includes(tag),
-		);
-		return {
-			params: { tag },
-			props: { posts: filteredPosts },
-		};
-	});
+	return Promise.all(
+		uniqueTags.map(async (tag) => {
+			const filteredPosts = englishPosts.filter((post) =>
+				post.data.tags.includes(tag),
+			);
+			const postsWithLanguages = await Promise.all(
+				filteredPosts.map(async (post) => ({
+					post,
+					availableLanguages: await getAvailableLanguages(post),
+				})),
+			);
+			return {
+				params: { tag },
+				props: { posts: postsWithLanguages },
+			};
+		}),
+	);
 }
 
 const { tag } = Astro.params;
-const { posts } = Astro.props;
+const { posts } = Astro.props as { posts: PostWithLanguages[] };
 ---
 
-<Layout>
-	<h1>Posts tagged with "{tag}"</h1>
+<Layout lang={lang}>
+	<h1>{t('blog.postsTaggedWith')} "{tag}"</h1>
 	<ul>
 		{
-			posts.map((post) => (
-				<BlogPostLink url={`/posts/${post.id}/`} title={post.data.title} />
+			posts.map(({ post, availableLanguages }) => (
+				<BlogPostLink
+					url={getPostUrl(post)}
+					title={post.data.title}
+					pubDate={post.data.pubDate}
+					lang={lang}
+					availableLanguages={availableLanguages}
+				/>
 			))
 		}
 	</ul>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,14 +1,17 @@
 ---
-// Tag index page - lists all unique tags from blog posts
-import { getCollection } from 'astro:content';
+// Tag index page - lists all unique tags from English blog posts
 import Layout from '../../layouts/Layout.astro';
+import { getPostsByLang } from '../../i18n/blog-utils';
+import { useTranslations } from '../../i18n/utils';
 
-const allPosts = await getCollection('blog');
-const tags = [...new Set(allPosts.map((post) => post.data.tags).flat())];
+const lang = 'en';
+const t = useTranslations(lang);
+const englishPosts = await getPostsByLang(lang);
+const tags = [...new Set(englishPosts.map((post) => post.data.tags).flat())];
 ---
 
-<Layout>
-	<h1>Tags</h1>
+<Layout lang={lang} description={t('meta.tags')}>
+	<h1>{t('blog.tags')}</h1>
 	<ul>
 		{
 			tags.map((tag) => (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,17 @@
+// General utility functions
+
+/**
+ * Get MIME type for an image URL based on file extension
+ */
+export function getImageMimeType(url: string): string {
+	const ext = url.split('.').pop()?.toLowerCase();
+	const types: Record<string, string> = {
+		png: 'image/png',
+		jpg: 'image/jpeg',
+		jpeg: 'image/jpeg',
+		gif: 'image/gif',
+		webp: 'image/webp',
+		svg: 'image/svg+xml',
+	};
+	return types[ext ?? ''] ?? 'image/jpeg';
+}


### PR DESCRIPTION
## Summary
- Add full i18n infrastructure with English (default) and German support
- Implement language switcher component in header
- Create German versions of all pages
- Update blog system to support translations between posts