### PR TITLE
fix: Add packageManager field to package.json (consistent in Actions + Dockerfile)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Stage 1: Build
 FROM node:24-alpine AS build
-RUN corepack enable
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
+# Install version of pnpm based on packageManager field in package.json
+RUN corepack enable && corepack install
 RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY . .

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "webpage",
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "pnpm@11.5.3",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Add the packageManager field to `package.json` so there is no drift between the pnpm version in the Action task and the Dockerfile (causing potential `pnpm install` errors).

## Related Issues

<!-- Link related issues here. Use "Closes #123" to auto-close issues when PR is merged -->

Closes #

## Type of Change

<!-- Please check the option that applies -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (non-functional changes)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test updates
- [x] 🔧 Configuration/build changes
- [ ] 🌐 Internationalization/localization
